### PR TITLE
feat: add postal code regex entries for 5 countries

### DIFF
--- a/src/postal_regex/data/postal_codes.json
+++ b/src/postal_regex/data/postal_codes.json
@@ -34,5 +34,10 @@
   {"country_code": "HU", "country_name": "Hungary", "postal_code_regex": "^[0-9]{4}$", "sample_valid": "1051", "sample_invalid": "ABCDE"},
   {"country_code": "GR", "country_name": "Greece", "postal_code_regex": "^[0-9]{3} ?[0-9]{2}$", "sample_valid": "151 24", "sample_invalid": "ABCDE"},
   {"country_code": "RO", "country_name": "Romania", "postal_code_regex": "^[0-9]{6}$", "sample_valid": "010011", "sample_invalid": "ABCDE"},
-  {"country_code": "CZ", "country_name": "Czech Republic", "postal_code_regex": "^[0-9]{3} ?[0-9]{2}$", "sample_valid": "110 00", "sample_invalid": "ABCDE"}
+  {"country_code": "CZ", "country_name": "Czech Republic", "postal_code_regex": "^[0-9]{3} ?[0-9]{2}$", "sample_valid": "110 00", "sample_invalid": "ABCDE"},
+  {"country_code": "AT", "country_name":"Austria", "postal_code_regex": "^[0-9]{4}$", "sample_valid": "1010", "sample_invalid": "ABCDE"},
+  {"country_code": "HR", "country_name": "Croatia","postal_code_regex": "^[1-5][0-9]{4}$","sample_valid": "10000", "sample_invalid": "ABCDE"},
+  {"country_code": "EG", "country_name": "Egypt", "postal_code_regex": "^[1-9][0-9]{4}$","sample_valid": "11511","sample_invalid": "ABCDE"},
+  {"country_code": "TH", "country_name": "Thailand", "postal_code_regex": "^[1-9][0-9]{4}$","sample_valid": "10110","sample_invalid": "ABCDE"},
+  {"country_code": "MA","country_name": "Morocco","postal_code_regex": "^[1-9][0-9]{4}$","sample_valid": "10000","sample_invalid": "ABCDE"}
 ]


### PR DESCRIPTION
## 📌 Pull Request

### Description
Postal code regex for Austria,Croatia,Egypt,Thailand and Morocco.

### Related Issue
Refs #1

### Changes Made
- Added  postal regex for Austria,Croatia,Egypt,Thailand and Morocco.


### Checklist
-Code follows project style guidelines.
-`pytest -v` passes locally.


