### PR TITLE
feat: Add Philippines, Chile, Israel, Malaysia, and Vietnam

### DIFF
--- a/src/postal_regex/data/postal_codes.json
+++ b/src/postal_regex/data/postal_codes.json
@@ -36,8 +36,14 @@
   {"country_code": "RO", "country_name": "Romania", "postal_code_regex": "^[0-9]{6}$", "sample_valid": "010011", "sample_invalid": "ABCDE"},
   {"country_code": "CZ", "country_name": "Czech Republic", "postal_code_regex": "^[0-9]{3} ?[0-9]{2}$", "sample_valid": "110 00", "sample_invalid": "ABCDE"},
   {"country_code": "AT", "country_name":"Austria", "postal_code_regex": "^[0-9]{4}$", "sample_valid": "1010", "sample_invalid": "ABCDE"},
-  {"country_code": "HR", "country_name": "Croatia","postal_code_regex": "^[1-5][0-9]{4}$","sample_valid": "10000", "sample_invalid": "ABCDE"},
-  {"country_code": "EG", "country_name": "Egypt", "postal_code_regex": "^[1-9][0-9]{4}$","sample_valid": "11511","sample_invalid": "ABCDE"},
-  {"country_code": "TH", "country_name": "Thailand", "postal_code_regex": "^[1-9][0-9]{4}$","sample_valid": "10110","sample_invalid": "ABCDE"},
-  {"country_code": "MA","country_name": "Morocco","postal_code_regex": "^[1-9][0-9]{4}$","sample_valid": "10000","sample_invalid": "ABCDE"}
+  {"country_code": "HR", "country_name": "Croatia", "postal_code_regex": "^[1-5][0-9]{4}$", "sample_valid": "10000", "sample_invalid": "ABCDE"},
+  {"country_code": "EG", "country_name": "Egypt", "postal_code_regex": "^[1-9][0-9]{4}$", "sample_valid": "11511", "sample_invalid": "ABCDE"},
+  {"country_code": "TH", "country_name": "Thailand", "postal_code_regex": "^[1-9][0-9]{4}$", "sample_valid": "10110", "sample_invalid": "ABCDE"},
+  {"country_code": "MA", "country_name": "Morocco","postal_code_regex": "^[1-9][0-9]{4}$","sample_valid": "10000", "sample_invalid": "ABCDE"},
+  {"country_code": "PH", "country_name": "Philippines", "postal_code_regex": "^[0-9]{4}$", "sample_valid": "1000", "sample_invalid": "ABCDE"},
+  {"country_code": "CL", "country_name": "Chile", "postal_code_regex": "^\\d{7}$", "sample_valid": "8320000", "sample_invalid": "12345"},
+  {"country_code": "IL", "country_name": "Israel", "postal_code_regex": "^\\d{7}$", "sample_valid": "9614303", "sample_invalid": "ABCDE"},
+  {"country_code": "MY", "country_name": "Malaysia", "postal_code_regex": "^\\d{5}$", "sample_valid": "50450", "sample_invalid": "ABCDE"},
+  {"country_code": "VN", "country_name": "Vietnam", "postal_code_regex": "^\\d{6}$", "sample_valid": "700000", "sample_invalid": "ABCDE"}
 ]
+

--- a/src/postal_regex/loader.py
+++ b/src/postal_regex/loader.py
@@ -50,6 +50,7 @@ def export_parquet(output_path: Union[str, Path]) -> Path:
     df.to_parquet(output_path, index=False)
     return output_path
 
+
 # ---------- CSV Saver ----------
 def export_csv(output_path: Union[str, Path]) -> Path:
     """Export postal codes to a CSV file."""


### PR DESCRIPTION
# Pull Request
### Description

Postal code regex for Philippines, Chile, Israel, Malaysia, and Vietnam.

### Related Issue

Related to #1 
### Changes Made

- Added postal regex for Philippines, Chile, Israel, Malaysia, and Vietnam
- Fixed `black` and `flake8` warning
- Fixed missing spaces in `json`

### Checklist

- Compliant with code style guidelines
- `pytest` tests are all passing except these two:

```
FAILED tests/test_loader.py::test_load_spark - pyspark.errors.exceptions.base.PySparkRuntimeError: [JAVA_GATEWAY_EXITED] Java gateway process exited before sending its port number.
FAILED tests/test_performance.py::test_load_spark_speed - pyspark.errors.exceptions.base.PySparkRuntimeError: [JAVA_GATEWAY_EXITED] Java gateway process exited before sending its port number.
```
I don't think the change has anything to do with them, but please recommend something if I'm mistaken and they can be fixed on my side somehow. I have $JAVA_HOME env var exported, if that has anything to do with it.