### PR TITLE
feat: add postal code regex for Uruguay, Colombia, Peru, Ecuador and Costa Rica

### DIFF
--- a/src/postal_regex/data/postal_codes.json
+++ b/src/postal_regex/data/postal_codes.json
@@ -44,6 +44,11 @@
   {"country_code": "CL", "country_name": "Chile", "postal_code_regex": "^\\d{7}$", "sample_valid": "8320000", "sample_invalid": "12345"},
   {"country_code": "IL", "country_name": "Israel", "postal_code_regex": "^\\d{7}$", "sample_valid": "9614303", "sample_invalid": "ABCDE"},
   {"country_code": "MY", "country_name": "Malaysia", "postal_code_regex": "^\\d{5}$", "sample_valid": "50450", "sample_invalid": "ABCDE"},
-  {"country_code": "VN", "country_name": "Vietnam", "postal_code_regex": "^\\d{6}$", "sample_valid": "700000", "sample_invalid": "ABCDE"}
+  {"country_code": "VN", "country_name": "Vietnam", "postal_code_regex": "^\\d{6}$", "sample_valid": "700000", "sample_invalid": "ABCDE"},
+  {"country_code": "UY", "country_name": "Uruguay", "postal_code_regex": "^[0-9]{5}$", "sample_valid": "11600", "sample_invalid": "ABCDE"},
+  {"country_code": "CO", "country_name": "Colombia", "postal_code_regex": "^[0-9]{6}$", "sample_valid": "110011", "sample_invalid": "12345"},
+  {"country_code": "PE", "country_name": "Peru", "postal_code_regex": "^[0-9]{5}$", "sample_valid": "15001", "sample_invalid": "ABCDE"},
+  {"country_code": "EC", "country_name": "Ecuador", "postal_code_regex": "^[0-9]{6}$", "sample_valid": "170135", "sample_invalid": "12345"},
+  {"country_code": "CR", "country_name": "Costa Rica", "postal_code_regex": "^[0-9]{5}$", "sample_valid": "10101", "sample_invalid": "ABCDE"}
 ]
 


### PR DESCRIPTION
This pull request updates the postal code data to improve coverage for Latin American countries. Six new countries have been added to the `postal_codes.json` file, each with their postal code regex patterns and sample codes for validation.

**Data coverage improvements:**

* Added postal code regex and sample codes for Uruguay (`UY`), Colombia (`CO`), Peru (`PE`), Ecuador (`EC`), and Costa Rica (`CR`) to `postal_codes.json` to support validation for these countries.
* Ensured that each new entry includes a regex pattern, a valid sample, and an invalid sample for improved testability.

- **Uruguay** (UY) – ^[0-9]{5}$ | valid: 11600 | invalid: ABCDE
- **Colombia** (CO) – ^[0-9]{6}$ | valid: 110011 | invalid: 12345
- **Peru** (PE) – ^[0-9]{5}$ | valid: 15001 | invalid: ABCDE
- **Ecuador** (EC) – ^[0-9]{6}$ | valid: 170135 | invalid: 12345
- **Costa Rica** (CR) – ^[0-9]{5}$ | valid: 10101 | invalid: ABCDE

All tests pass successfully with `pytest -v`.

Related to #1
