### PR TITLE
Feat: Allow postal code extraction from embedded text

### DIFF
--- a/src/postal_regex/core.py
+++ b/src/postal_regex/core.py
@@ -89,3 +89,12 @@ def get_country_regex(country_identifier: str) -> str:
     """
     entry = get_entry(country_identifier)
     return entry.regex.pattern
+
+def extract_postal_code(country_identifier: str, text: str) -> str | None:
+    """
+    Extract the first postal code from text that matches the country's regex pattern.
+    Returns None if no match is found.
+    """
+    pattern = get_country_regex(country_identifier)
+    match = regex.search(pattern.strip('^$'), text)
+    return match.group(0) if match else None


### PR DESCRIPTION
📌 Pull Request
Description
extracts the first postal code from a given text by using a country's regex pattern, with the start (`^`) and end (`$`) anchors removed to allow matching anywhere in the text. It returns the matched postal code as a string or `None` if no match is found.

Related Issue
Refs #17 

Changes Made
The core change made in the Python function was to modify the regular expression pattern to allow it to match a substring within a larger text, specifically by removing the start (^) and end ($) anchors.

Checklist
[✓] Tests added/updated 
[✓] Code follows project style guidelines
[✓] pytest -v passes locally
[ x] Documentation updated