### PR TITLE
docs: add validation examples for all 5 recently added South Asian countries (ID, BD, PK, LK, NP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,29 +13,71 @@ Ideal for **form validation, data cleaning, and big data applications**.
 
 ## Table of Contents
 
-- [Features](#features)
 - [Installation](#installation)
-- [Usage](#usage)
+- [Quick Start](#quick-start)
+- [Features](#features)
+- [Command-Line Usage](#command-line-usage)
 - [Big Data Support](#big-data-support)
 - [Contributing](#contributing)
 - [License](#license)
 
 ---
 
-## Features
+## Installation
 
-- ✅ 50+ countries included, with postal code regex patterns  
-- ✅ Validate postal codes by **country code** or **country name**
+```bash
+pip install postal-regex
+```
+
+For development:
+
+```bash
+git clone https://github.com/ankitgadling/postal-regex.git
+cd postal-regex
+pip install -e .
+```
+
+---
+
+## Quick Start
+
 ```python
 from postal_regex.core import validate
 
+# Validate by country code
 validate("IN", "110001")      # True
-validate("India", "110001")   # True
 validate("US", "12345-6789")  # True
-````
 
-## Examples for recently added countries (Indonesia, Bangladesh, Pakistan, Sri Lanka, Nepal)
+# By country name
+validate("India", "110001")   # True
+
+# Invalid returns False
+validate("US", "ABCDE")       # False
+```
+
+---
+
+## Features
+
+- ✅ 50+ countries included, with postal code regex patterns
+- ✅ Validate postal codes by **country code** or **country name**
+- ✅ Normalize country identifiers
+
 ```python
+from postal_regex.core import normalize
+
+normalize("United States")  # "US"
+normalize("India")          # "IN"
+```
+
+- ✅ Works with **Pandas and Spark DataFrames**
+- ✅ JSON schema ensures consistent data structure
+- ✅ Precompiled regex for fast Python validation
+
+### Examples for Recently Added Countries (Indonesia, Bangladesh, Pakistan, Sri Lanka, Nepal)
+
+```python
+from postal_regex.core import validate
 
 # Indonesia (ID)
 validate("ID", "12345")           # **Expected: True** (valid 5-digit code)
@@ -54,43 +96,56 @@ validate("LK", "00300")           # **Expected: True** (valid 5-digit code, e.g.
 validate("NP", "44600")           # **Expected: True** (valid 5-digit code, e.g., Kathmandu)
 ```
 
-* ✅ Normalize country identifiers
-
-```python
-from postal_regex.core import normalize
-
-normalize("United States")  # "US"
-normalize("India")          # "IN"
-```
-
-* ✅ Works with **Pandas and Spark DataFrames**
-
-```python
-import pandas as pd
-from postal_regex.bulk import validate_dataframe
-
-df = pd.DataFrame({"country": ["US", "FR"], "postal_code": ["90210", "75001"]})
-df_validated = validate_dataframe(df, country_col="country", postal_col="postal_code")
-print(df_validated)
-```
-
-* ✅ JSON schema ensures consistent data structure
-* ✅ Precompiled regex for fast Python validation
-
 ---
 
-## Installation
+## Command-Line Usage
 
-```bash
-pip install postal-regex
+You can validate postal codes directly from the command line without writing any code.
+
+### Validate Postal Codes
+
+To validate one or more postal codes for a specific country:
+
+```sh
+python -m postal_regex.cli validate <postal_code1> <postal_code2> ... <country>
 ```
 
-For development:
+**Examples:**
 
-```bash
-git clone https://github.com/ankitgadling/postal-regex.git
-cd postal-regex
-pip install -e .
+Validate a single code for India:
+```sh
+python -m postal_regex.cli validate 110001 IN
+```
+Output:
+```
+110001: Valid
+```
+
+Validate multiple codes for the United States:
+```sh
+python -m postal_regex.cli validate 12345 90210 US
+```
+Output:
+```
+12345: Valid
+90210: Valid
+```
+
+You can also use country names:
+```sh
+python -m postal_regex.cli validate 110001 India
+```
+
+### View Validation Statistics
+
+To view local validation statistics:
+```sh
+python -m postal_regex.cli stats
+```
+
+To reset statistics:
+```sh
+python -m postal_regex.cli stats --reset
 ```
 
 ---
@@ -130,64 +185,24 @@ print(df_validated)
 
 ---
 
-## Command-Line Usage
-
-You can validate postal codes directly from the command line without writing any code.
-
-### Validate Postal Codes
-
-To validate one or more postal codes for a specific country:
-
-```sh
-python -m postal_regex.cli validate <postal_code1> <postal_code2> ... <country>
-```
-
-**Examples:**
-
-Validate a single code for India:
-```
-python -m postal_regex.cli validate 110001 IN
-```
-Output:
-```
-110001: Valid
-```
-
-Validate multiple codes for the United States:
-```
-python -m postal_regex.cli validate 12345 90210 US
-```
-Output:
-```
-12345: Valid
-90210: Valid
-```
-
-You can also use country names:
-```
-python -m postal_regex.cli validate 110001 India
-```
-
-### View Validation Statistics
-
-To view local validation statistics:
-```
-python -m postal_regex.cli stats
-```
-
-To reset statistics:
-```
-python -m postal_regex.cli stats --reset
-```
-
----
-
 ## Contributing
 
-We welcome contributions! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+We ❤️ contributions! Help expand coverage or improve docs.
+
+1. Fork the repo and create a feature branch: `git checkout -b feat/new-country`.
+2. Add/update patterns in `postal_regex/data/` (follow JSON schema).
+3. Run tests: `pytest`.
+4. Commit and push: `git commit -m "Add postal patterns for [Country]"`.
+5. Open a Pull Request—reference any related issue.
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed guidelines, including testing new patterns and updating examples.
 
 ---
 
 ## License
 
 MIT License. See [LICENSE](LICENSE) for details.
+
+---
+
+⭐ **Star this repo** if it's useful! Found a bug or missing country? [Open an issue](https://github.com/ankitgadling/postal-regex/issues). Questions? Join the discussion!


### PR DESCRIPTION
## 📌 Pull Request

### Description
Updated README.md with usage examples for the five recently added countries from [commit #16]: Indonesia (ID), Bangladesh (BD), Pakistan (PK), Sri Lanka (LK), and Nepal (NP).

Addresses the issue by adding:
- Code snippets showing `validate()` calls (with country codes and full names).
- Highlighted expected outputs (`**Expected: True**`).

### Changes Made
- [ ] Added/Updated postal regex for a new country
- [ ] Improved documentation

### Screenshots
<img width="920" height="412" alt="image" src="https://github.com/user-attachments/assets/ce7155d9-d8ac-4991-a333-7212c3dbd07d" />
<img width="894" height="124" alt="image" src="https://github.com/user-attachments/assets/e6a33d45-5211-4485-87eb-ca3ca36bb263" />
